### PR TITLE
Fix amqp shutdown method

### DIFF
--- a/lib/amqp-client.js
+++ b/lib/amqp-client.js
@@ -220,7 +220,7 @@
           mq.backoff = mq.reconnect = mq.connect = function() {
             return false;
           };
-          mq.end();
+          mq.disconnect();
           log.info('amqp closed');
           return def.resolve(true);
         });

--- a/src/amqp-client.coffee
+++ b/src/amqp-client.coffee
@@ -5,7 +5,7 @@ ExchangeWrapper = require './exchange-wrapper'
 QueueWrapper    = require './queue-wrapper'
 
 module.exports = (conf) ->
-        
+
     local = conf.local || process.env.LOCAL
     log.info("local means no amqp connection") if local
 
@@ -35,7 +35,7 @@ module.exports = (conf) ->
         def.promise
 
     exchange = (name, opts) ->
-        return Q(name) if name instanceof ExchangeWrapper 
+        return Q(name) if name instanceof ExchangeWrapper
         throw new Error 'Unable connect exchange when local' if local
         throw new Error 'Unable connect exchange when shutdown' if isShutdown
         def = Q.defer()
@@ -55,7 +55,7 @@ module.exports = (conf) ->
         def.promise
 
     queue = (qname, opts) =>
-        return Q(qname) if qname instanceof QueueWrapper 
+        return Q(qname) if qname instanceof QueueWrapper
         throw new Error 'Unable to connect queue when local' if local
         throw new Error 'Unable to connect queue shutdown' if isShutdown
         if qname != null and typeof qname == 'object'
@@ -132,7 +132,7 @@ module.exports = (conf) ->
                 log.info 'closing amqp connection'
                 # compensate for utterly broken reconnect code
                 mq.backoff = mq.reconnect = mq.connect = -> false
-                mq.end()
+                mq.disconnect()
                 log.info 'amqp closed'
                 def.resolve true
         .done()


### PR DESCRIPTION
The documented way of closing the connection is to call disconnect, not
end. This removes warnings we are seeing in the rabbit log. Also fix
some incorrect whitespaces.